### PR TITLE
Fixed es6 CLI argument detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ function main(args) {
     if (key === '_') {
       var pos_args = args[key];
 
-      if (_.contains(pos_args[key], "es6")) {
+      if (_.contains(pos_args, "es6")) {
         /* Global Settings Object */
         settings['template_type'] = "es6";
       }


### PR DESCRIPTION
Current npm version (0.2.2) doesn't use ES6 template when `--es6` used in CLI. This fixes it.
